### PR TITLE
Fix O(N*2) list modification

### DIFF
--- a/cif/smrt/__init__.py
+++ b/cif/smrt/__init__.py
@@ -37,10 +37,7 @@ class Smrt(Client):
         self.logger.debug('parsing')
         data = Pipe().process(rule, feed, data)
 
-        for d in range(0, len(data)):
-            x = Observable(**data[d])
-            data.pop(d)
-            data.insert(d, x)
+        data = [Observable(**item) for item in data]
 
 
         self.logger.debug('submitting')

--- a/cif/smrt/parser/delim.py
+++ b/cif/smrt/parser/delim.py
@@ -27,9 +27,9 @@ class Delim(Pattern):
             if len(cols):
                 obs = defaults
 
-                for c in range(0, len(cols)):
-                    if cols[c] is not None:
-                        obs[cols[c]] = m[c]
+                for idx, col in enumerate(cols):
+                    if col is not None:
+                        obs[col] = m[idx]
                 obs.pop("values", None)
                 rv.append(obs)
 

--- a/cif/smrt/parser/pattern.py
+++ b/cif/smrt/parser/pattern.py
@@ -30,9 +30,9 @@ class Pattern(Parser):
             m = self.pattern.split(l)
             if len(cols):
                 obs = rule.defaults
-                for c in range(0, len(cols)):
-                    if cols[c] is not None:
-                        obs[cols[c]] = m[c]
+                for idx, col in enumerate(cols):
+                    if col is not None:
+                        obs[col] = m[idx]
                 obs.pop("values", None)
                 rv.append(obs)
 


### PR DESCRIPTION
list.pop and list.insert are both O(N), a quick test shows that this
loop over 262144 items takes about 30 seconds.

This fixes the immediate problem:

    for d in range(0, len(data)):
        x = Observable(**data[d])
        data[d] = x

but list comprehensions are simpler and slightly faster.