### PR TITLE
Fix affecting longitude twice

### DIFF
--- a/cif/gatherer/geo.py
+++ b/cif/gatherer/geo.py
@@ -44,7 +44,7 @@ class Geo(object):
                 indicator.longitude = g.location.longitude
 
             if g.location.latitude:
-                indicator.longitude = g.location.latitude
+                indicator.latitude = g.location.latitude
 
             if g.location.time_zone:
                 indicator.timezone = g.location.time_zone


### PR DESCRIPTION
Fixes the Geo class's _resolve method that overwrites the longitude with
the latitude.