### PR TITLE
problem: dns resolver library uses search domains

### DIFF
--- a/cif/utils.py
+++ b/cif/utils.py
@@ -11,6 +11,7 @@ def resolve_ns(data, t='A', timeout=HUNTER_RESOLVER_TIMEOUT):
     resolver = dns.resolver.Resolver()
     resolver.timeout = timeout
     resolver.lifetime = timeout
+    resolver.search = []
     try:
         answers = resolver.query(data, t)
         resp = []


### PR DESCRIPTION
By default the resolver parses /etc/resolv.conf and this causes the
intended query amount to multiply as it attempts to use the search
domains.