### PR TITLE
problem: reporttime column is missing an index

### DIFF
--- a/cif/store/sqlite/indicator.py
+++ b/cif/store/sqlite/indicator.py
@@ -118,7 +118,7 @@ class Ipv4(Base):
     __tablename__ = 'indicators_ipv4'
 
     id = Column(Integer, primary_key=True)
-    ipv4 = Column(Ip)
+    ipv4 = Column(Ip, index=True)
     mask = Column(Integer, default=32)
 
     indicator_id = Column(Integer, ForeignKey('indicators.id', ondelete='CASCADE'))
@@ -131,7 +131,7 @@ class Ipv6(Base):
     __tablename__ = 'indicators_ipv6'
 
     id = Column(Integer, primary_key=True)
-    ip = Column(Ip(version=6))
+    ip = Column(Ip(version=6), index=True)
     mask = Column(Integer, default=64)
 
     indicator_id = Column(Integer, ForeignKey('indicators.id', ondelete='CASCADE'))

--- a/cif/store/sqlite/indicator.py
+++ b/cif/store/sqlite/indicator.py
@@ -37,7 +37,7 @@ class Indicator(Base):
     asn = Column(Float)
     cc = Column(String)
     protocol = Column(Integer)
-    reporttime = Column(DateTime)
+    reporttime = Column(DateTime, index=True)
     firsttime = Column(DateTime)
     lasttime = Column(DateTime)
     confidence = Column(Float)


### PR DESCRIPTION
queries use

ORDER BY indicators.reporttime DESC

and this is slow without this index.

I'm almost positive that other fields should have indexes as well, particularly indicator and itype, but I haven't verified it yet.