### PR TITLE
Move to ES daily index creation

### DIFF
--- a/cif/store/zelasticsearch/indicator.py
+++ b/cif/store/zelasticsearch/indicator.py
@@ -58,7 +58,7 @@ class Indicator(DocType):
 
 def _current_index():
     dt = datetime.utcnow()
-    dt = dt.strftime('%Y.%m')
+    dt = dt.strftime('%Y.%m.%d')
     idx = '{}-{}'.format('indicators', dt)
     return idx
 


### PR DESCRIPTION
Background:
Daily indicies are more flexible for later data archives/removes.
Another benefit: Changes to the mappings will apply automagically next day