### PR TITLE
Hosts with selinux enabled require libselinux-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ msgpack-python>=0.4.8,<0.5.0
 csirtg_smrt==0.0.0a22
 csirtg_dnsdb>=0.0.0a3,<1.0
 tornado>=4.4.1,<5.0
+libselinux-python # Required where selinux is enabled


### PR DESCRIPTION
TASK [centos7 : Copy firewall script into place.] ******************************
task path: /home/cif/bearded-avenger-3.0.0a15/deployment/centos7/roles/centos7/tasks/firewall.yml:4
fatal: [localhost]: FAILED! => {"changed": true, "failed": true, "msg": "Aborting, target uses selinux but python bindings (libselinux-python) aren't installed!"}
	to retry, use: --limit @/home/cif/bearded-avenger-3.0.0a15/deployment/centos7/localhost.retry