### PR TITLE
Elasticsearch Geo-point datatype

### DIFF
--- a/cif/gatherer/geo.py
+++ b/cif/gatherer/geo.py
@@ -119,6 +119,9 @@ class Geo(object):
 
         if g.location.latitude:
             indicator.latitude = g.location.latitude
+            
+        if g.location.latitude and g.location.longitude:
+            indicator.location = [g.location.longitude, g.location.latitude]
 
         if g.location.time_zone:
             indicator.timezone = g.location.time_zone

--- a/cif/store/zelasticsearch/schema.py
+++ b/cif/store/zelasticsearch/schema.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import DocType, Text, Date, Integer, Float, Ip, Text, Keyword
+from elasticsearch_dsl import DocType, Text, Date, Integer, Float, Ip, Text, Keyword, GeoPoint
 
 
 class Indicator(DocType):
@@ -26,3 +26,4 @@ class Indicator(DocType):
     rdata = Keyword()
     count = Integer()
     message = Text(multi=True)
+    location = GeoPoint()


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html#geo-point

Elasticsearch require a field of type geo point for querying the data : 
- to find geo-points within a bounding box, within a certain distance of a central point, or within a polygon.
- to aggregate documents by geographically or by distance from a central point.
- to integrate distance into a document’s relevance score.
- to sort documents by distance.

This pull request address the issue #342 by 

1) adding a "location" field to the document 
```python
location = GeoPoint()
```

2) appending the data to the indicator document
```python         
if g.location.latitude and g.location.longitude:
    indicator.location = [g.location.longitude, g.location.latitude]
```

I would love to add a test case, but there seems to be no example for latitude/longitude tests, so I would appreciate any guidance how to add the test case.