### PR TITLE
Move the commit/rollback inside the loop that iterates over data items.

### DIFF
--- a/cif/store/sqlite/indicator.py
+++ b/cif/store/sqlite/indicator.py
@@ -626,15 +626,15 @@ class IndicatorManager(IndicatorManagerPlugin):
             # see test_store_sqlite
             d['tags'] = ','.join(tags)
 
-        logger.debug('committing')
-        start = time.time()
-        try:
-            s.commit()
-        except Exception as e:
-            n = 0
-            logger.error(e)
-            logger.debug('rolling back transaction..')
-            s.rollback()
+            logger.debug('committing')
+            start = time.time()
+            try:
+                s.commit()
+            except Exception as e:
+                n = 0
+                logger.error(e)
+                logger.debug('rolling back transaction..')
+                s.rollback()
 
         logger.debug('done: %0.2f' % (time.time() - start))
         return n


### PR DESCRIPTION
Ensures that exceptions raised from indicator upserts are handled and rolled-back item by item rather than as a whole batch.

