### PR TITLE
Commit indicators one at a time if the initial batch fails

### DIFF
--- a/cif/store/__init__.py
+++ b/cif/store/__init__.py
@@ -209,14 +209,14 @@ class Store(multiprocessing.Process):
             _t = self.store.tokens.write(t)
             try:
                 start_time = time.time()
-                logger.info('inserting %d indicators..', len(data))
+                logger.info('attempting to insert %d indicators..', len(data))
 
-                rv = self.store.indicators.upsert(_t, data)
+                n = self.store.indicators.upsert(_t, data)
 
-                n = len(data)
+                #n = len(data)
                 t_time = time.time() - start_time
-                logger.info('inserting %d indicators.. took %0.2f seconds (%0.2f/sec)', n, t_time, (n / t_time))
-                rv = {"status": "success", "data": rv}
+                logger.info('actually inserted %d indicators.. took %0.2f seconds (%0.2f/sec)', n, t_time, (n / t_time))
+                rv = {"status": "success", "data": n}
 
             except AuthError as e:
                 rv = {'status': 'failed', 'message': 'unauthorized'}
@@ -242,7 +242,7 @@ class Store(multiprocessing.Process):
 
         if len(data) > 1:
             start_time = time.time()
-            logger.info('inserting %d indicators..', len(data))
+            logger.info('attempting to insert %d indicators..', len(data))
 
             # this will raise AuthError if the groups don't match
             if isinstance(data, dict):
@@ -261,13 +261,13 @@ class Store(multiprocessing.Process):
                     except (TypeError, binascii.Error) as e:
                         pass
 
-            r = self.store.indicators.upsert(t, data, flush=flush)
+            n = self.store.indicators.upsert(t, data, flush=flush)
 
-            n = len(data)
+            #n = len(data)
             t = time.time() - start_time
-            logger.info('inserting %d indicators.. took %0.2f seconds (%0.2f/sec)', n, t, (n/t))
+            logger.info('actually inserted %d indicators.. took %0.2f seconds (%0.2f/sec)', n, t, (n/t))
 
-            return r
+            return n
 
         data = data[0]
         if data['group'] not in t['groups']:

--- a/cif/store/sqlite/indicator.py
+++ b/cif/store/sqlite/indicator.py
@@ -626,15 +626,15 @@ class IndicatorManager(IndicatorManagerPlugin):
             # see test_store_sqlite
             d['tags'] = ','.join(tags)
 
-        logger.debug('committing')
-        start = time.time()
-        try:
-            s.commit()
-        except Exception as e:
-            n = 0
-            logger.error(e)
-            logger.debug('rolling back transaction..')
-            s.rollback()
+            logger.debug('committing')
+            start = time.time()
+            try:
+                s.commit()
+            except Exception as e:
+                n = 0
+                logger.error(e)
+                logger.debug('rolling back transaction..')
+                s.rollback()
 
         logger.debug('done: %0.2f' % (time.time() - start))
         return n


### PR DESCRIPTION
The existing  code dumps all indicators in a batch if one of them fails to commit.  This means that you may loose all the indicators if one fails.

Our initial PR looked to commit per indicator, but this had some performance issues.

This PR is a compromise between the two.
It keeps the original functionality in the base case (batch with a commit at the end).  If an exception is thrown at any point while processing the batch, then we rollback the batch and iterate over the indicators again committing them one by one.

This means that you only lose the indicators which are actually causing the issue, while the other ones make it in.

It looks like this doesn't have the performance issues that the previous PR suffered from.

INFO - cif.store[212][MainThread] - attempting to insert 1000 indicators..
INFO - cif.store[218][MainThread] - inserting 1000 indicators.. took 7.23 seconds (138.33/sec)
INFO - cif.store[212][MainThread] - attempting to insert 1000 indicators..
INFO - cif.store[218][MainThread] - inserting 995 indicators.. took 6.16 seconds (161.52/sec)
INFO - cif.store[212][MainThread] - attempting to insert 1000 indicators..
INFO - cif.store[218][MainThread] - inserting 997 indicators.. took 6.18 seconds (161.42/sec)
INFO - cif.store[212][MainThread] - attempting to insert 535 indicators..
INFO - cif.store[218][MainThread] - inserting 534 indicators.. took 3.05 seconds (175.29/sec)