### PR TITLE
fix for cif-tokens delete for ES

### DIFF
--- a/cif/store/zelasticsearch/token.py
+++ b/cif/store/zelasticsearch/token.py
@@ -94,7 +94,7 @@ class TokenManager(TokenManagerPlugin):
             t.delete()
 
         connections.get_connection().indices.flush(index='tokens')
-        return len(rv)
+        return len(list(rv))
 
     def edit(self, data):
         if not data.get('token'):


### PR DESCRIPTION
Stop cif-tokens --delete-token from causing an error when using Elasticsearch