### PR TITLE
Fixes issue in cif-store where message queues get prematurely deleted

### DIFF
--- a/cif/store/__init__.py
+++ b/cif/store/__init__.py
@@ -202,7 +202,7 @@ class Store(multiprocessing.Process):
     def _flush_create_queue(self):
         for t in self.create_queue:
             if len(self.create_queue[t]['messages']) == 0:
-                return
+                continue
 
             logger.debug('flushing queue...')
             data = [msg[0] for _, _, msg in self.create_queue[t]['messages']]


### PR DESCRIPTION
This pull request is to remediate an issue where message queues are prematurely emptied before inserting indicators into the database. 

When any of the message queues are empty, the "return" statement causes all queues after the empty queue to be deleted without being submitted to the database. 

By replacing "return" with "continue," this allows message queues after the empty queue to be processed prior to deletion.