### PR TITLE
Setting pytest-cov upper version limit to 2.6.0

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
 coverage>=4.2
-pytest-cov>=2.2.1
+pytest-cov>=2.2.1,<2.6.1
 pytest>=2.8.0,<3.0
 -r requirements.txt


### PR DESCRIPTION
Fixes #442 

