### PR TITLE
Fix token operations for elasticsearch

### DIFF
--- a/cif/store/zelasticsearch/token.py
+++ b/cif/store/zelasticsearch/token.py
@@ -100,12 +100,22 @@ class TokenManager(TokenManagerPlugin):
         if not data.get('token'):
             return 'token required for updating'
 
-        d = list(self.search({'token': data['token']}))
+        d = list(self.search({'token': data['token']}, raw=True))
         if not d:
             return 'token not found'
 
-        d.update(fields=data)
+        d = Token.get(d[0]['_id'])
+
+        try:
+            d.update(groups=data['groups'])
+
+        except Exception as e:
+            import traceback
+            logger.error(traceback.print_exc())
+            return False
+
         connections.get_connection().indices.flush(index='tokens')
+        return True
 
     def update_last_activity_at(self, token, timestamp):
         if isinstance(timestamp, str):

--- a/cif/store/zelasticsearch/token.py
+++ b/cif/store/zelasticsearch/token.py
@@ -84,7 +84,7 @@ class TokenManager(TokenManagerPlugin):
         if not (data.get('token') or data.get('username')):
             return 'username or token required'
 
-        rv = self.search(data, raw=True)
+        rv = list(self.search(data, raw=True))
 
         if not rv:
             return 0
@@ -94,7 +94,7 @@ class TokenManager(TokenManagerPlugin):
             t.delete()
 
         connections.get_connection().indices.flush(index='tokens')
-        return len(list(rv))
+        return len(rv)
 
     def edit(self, data):
         if not data.get('token'):


### PR DESCRIPTION
Partial fix for #440. `--delete-token <token>` is now returning the correct status but `--delete --username <username>` is not functional when using an email as the username. This is due to elasticsearch's default "tokenization" behavior (foo@bar.com "tokenized" as foo,bar,com). This requires further investigation as I don't have a clear solution for this atm.  

Also fixed the update (edit) function to update groups appropriately. 