### PR TITLE
problem: emails, and urls, and other strings aren't able to be searched with cif-tokens.

### DIFF
--- a/helpers/es.sh
+++ b/helpers/es.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-VERSION=5.6.4
+VERSION=5.6.16
 
 docker run -p 9200:9200 -p 9300:9300 elasticsearch:$VERSION


### PR DESCRIPTION
emails, and urls, and other strings aren't able to be searched with cif-tokens.

This is because 'tokens' index didn't have fields set as 'not_analyzed'. This checks for the old 'tokens' index and creates a 'tokens_new' index, reindexes the data to the new index, removes the old and creates an alias for 'tokens' for the new index.

Also, updates ES version in the helper script, to equal what the deployment kit was updated to.