### PR TITLE
problem: Group search does not respect token permissions

### DIFF
--- a/cif/store/__init__.py
+++ b/cif/store/__init__.py
@@ -377,6 +377,21 @@ class Store(multiprocessing.Process):
                 if isinstance(data['indicator'], str):
                     data['indicator'] = unicode(data['indicator'])
 
+        # verify group filter matches token permissions
+        if data.get('groups'):
+            q_groups = [g.strip() for g in data['groups'].split(',')]
+
+            gg = []
+            for g in q_groups:
+                if g in t['groups']:
+                    gg.append(g)
+
+            if gg:
+                data['groups'] = gg
+            else:
+                data['groups'] = '{}'
+
+
         if not data.get('reporttime'):
             if data.get('days'):
                 now = arrow.utcnow()


### PR DESCRIPTION
Fix #462:
- verifies group filter matches token groups
- adds support for multi-group searches (e.g. `--groups foo,everyone` or `--groups 'foo , everyone'` )