### PR TITLE
problem: hunters closing sockets prematurely

### DIFF
--- a/cif/hunter/__init__.py
+++ b/cif/hunter/__init__.py
@@ -67,7 +67,7 @@ class Hunter(multiprocessing.Process):
         self.exit.set()
 
     def start(self):
-        router = Client(remote=self.router, token=self.token, nowait=True)
+        router = Client(remote=self.router, token=self.token, nowait=True, autoclose=False)
         plugins = self._load_plugins()
         socket = zmq.Context().socket(zmq.PULL)
 


### PR DESCRIPTION
Hunters closing sockets causing hunters to fail. This problem was introduced in https://github.com/csirtgadgets/bearded-avenger-sdk-py/pull/91

Added support for autoclose, which signals sdk to not close the zeromq socket when called from the hunter. 