### PR TITLE
feature: adding delete function for elasticsearch

### DIFF
--- a/cif/httpd/common.py
+++ b/cif/httpd/common.py
@@ -5,7 +5,7 @@ import gzip
 from base64 import b64encode
 
 VALID_FILTERS = ['indicator', 'itype', 'confidence', 'provider', 'limit', 'application', 'nolog', 'tags', 'days',
-                 'hours', 'groups', 'reporttime', 'cc', 'asn', 'asn_desc', 'rdata', 'firsttime', 'lasttime', 'region']
+                 'hours', 'groups', 'reporttime', 'cc', 'asn', 'asn_desc', 'rdata', 'firsttime', 'lasttime', 'region', 'id']
 TOKEN_FILTERS = ['username', 'token']
 
 

--- a/cif/store/zelasticsearch/constants.py
+++ b/cif/store/zelasticsearch/constants.py
@@ -20,3 +20,8 @@ if UPSERT_MODE == '1':
     UPSERT_MODE = True
 
 PARTITION = os.getenv('CIF_STORE_ES_PARTITION', 'month')
+
+DELETE_FILTERS = [
+            'id',
+            'indicator'
+        ]

--- a/cif/store/zelasticsearch/constants.py
+++ b/cif/store/zelasticsearch/constants.py
@@ -21,7 +21,6 @@ if UPSERT_MODE == '1':
 
 PARTITION = os.getenv('CIF_STORE_ES_PARTITION', 'month')
 
-DELETE_FILTERS = [
-            'id',
-            'indicator'
-        ]
+DELETE_FILTERS = os.getenv('CIF_STORE_ES_DELETE_FILTERS', 'id, indicator, provider')
+DELETE_FILTERS = DELETE_FILTERS.split(',')
+DELETE_FILTERS = list(set((x.strip() for x in DELETE_FILTERS)))

--- a/cif/store/zelasticsearch/filters.py
+++ b/cif/store/zelasticsearch/filters.py
@@ -157,6 +157,15 @@ def filter_groups(s, q_filters, token=None):
 
     return s
 
+def filter_id(s, q_filters):
+    if not q_filters.get('id'):
+        return s
+
+    id = q_filters.pop('id')
+
+    s.query = Q('match_phrase', uuid=id)
+
+    return s
 
 def filter_build(s, filters, token=None):
     q_filters = {}
@@ -166,6 +175,8 @@ def filter_build(s, filters, token=None):
 
     # treat indicator as special, transform into Search
     s = filter_indicator(s, q_filters)
+
+    s = filter_id(s, q_filters)
 
     s = filter_confidence(s, q_filters)
 


### PR DESCRIPTION
delete by id (uuid), indicator, and provider by default. Filter can be modified using the `CIF_STORE_ES_DELETE_FILTERS` env variable.  

Examples:
```
cif --delete --indicator 1.2.3.4

cif -nq 5.6.7.8 --format csv --fields uuid
cif --delete --id <uuid>

cif --delete --provider foo
```