### PR TITLE
Fix typo in Arrow object function

### DIFF
--- a/cif/store/sqlite/indicator.py
+++ b/cif/store/sqlite/indicator.py
@@ -342,7 +342,7 @@ class IndicatorManager(IndicatorManagerPlugin):
                 if ',' in filters[k]:
                     start, end = filters[k].split(',')
                     s = s.filter(Indicator.reporttime >= arrow.get(start).datetime)
-                    s = s.filter(Indicator.reporttime <= arrow.get(end).datettime)
+                    s = s.filter(Indicator.reporttime <= arrow.get(end).datetime)
                 else:
                     s = s.filter(Indicator.reporttime >= arrow.get(filters[k]).datetime)
 


### PR DESCRIPTION
.datettime corrected to .datetime - specifically affects sqlite-backed instances