### PR TITLE
fix PATCH /tokens removing group from all tokens (sqlite)

### DIFF
--- a/cif/store/sqlite/token.py
+++ b/cif/store/sqlite/token.py
@@ -151,10 +151,10 @@ class TokenManager(TokenManagerPlugin):
 
         s = self.handle()
         rv = s.query(Token).filter_by(token=data['token'])
-        if not rv.first():
+        t = rv.first()
+        if not t:
             return 'token not found'
 
-        t = rv.first()
         groups = [g.group for g in t.groups]
 
         for g in data['groups']:
@@ -175,7 +175,7 @@ class TokenManager(TokenManagerPlugin):
             if g in data['groups']:
                 continue
 
-            rv = q.filter_by(group=g)
+            rv = q.filter_by(group=g, token=t)
             if not rv.count():
                 continue
 


### PR DESCRIPTION
reduced 2 calls to rv.first() to just 1. 
in edit() function under group removal, add criteria to match on token object in filter_by to prevent removing the same group from all other tokens (and not just targeted token)

This fixes the following:

Issue: when issuing a PATCH to /tokens for a specific token_id, that token_id is indeed correctly updated. however, all other tokens have all their groups removed.

Steps to reproduce issue:
1. Create several tokens in a test CIF instance using sqlite store
2. Set all tokens to use group 'everyone'
3. Issue PATCH http method against /tokens endpoint with json body to set one of the tokens to another group like "test," ie: { "token": "token_id", "groups": ["test"] }
4. GET /tokens and see that the targeted token_id is now a member of only "test" group, but all other tokens have no group memberships
