### PR TITLE
Return helpful msg if limit > WINDOW_LIMIT

### DIFF
--- a/cif/store/__init__.py
+++ b/cif/store/__init__.py
@@ -177,7 +177,7 @@ class Store(multiprocessing.Process):
             err = 'unauthorized'
 
         except InvalidSearch as e:
-            err = 'invalid search'
+            err = 'invalid search {}'.format(e)
 
         except InvalidIndicator as e:
             logger.error(data)
@@ -436,7 +436,7 @@ class Store(multiprocessing.Process):
             if logger.getEffectiveLevel() == logging.DEBUG:
                 logger.error(traceback.print_exc())
 
-            raise InvalidSearch('invalid search')
+            raise InvalidSearch(': {}'.format(e))
 
         logger.debug('%s' % (time.time() - s))
 

--- a/cif/store/zelasticsearch/filters.py
+++ b/cif/store/zelasticsearch/filters.py
@@ -8,6 +8,7 @@ from elasticsearch_dsl import Q
 import ipaddress
 import arrow
 
+from cif.store.zelasticsearch.constants import WINDOW_LIMIT
 from cif.httpd.common import VALID_FILTERS
 
 
@@ -168,6 +169,10 @@ def filter_id(s, q_filters):
     return s
 
 def filter_build(s, filters, token=None):
+    limit = filters.get('limit')
+    if limit and limit > WINDOW_LIMIT:
+        raise InvalidSearch('request limit should be <= server threshold of {} but was set to {}'.format(WINDOW_LIMIT, limit))
+        
     q_filters = {}
     for f in VALID_FILTERS:
         if filters.get(f):

--- a/cif/store/zelasticsearch/filters.py
+++ b/cif/store/zelasticsearch/filters.py
@@ -170,7 +170,7 @@ def filter_id(s, q_filters):
 
 def filter_build(s, filters, token=None):
     limit = filters.get('limit')
-    if limit and limit > WINDOW_LIMIT:
+    if limit and int(limit) > WINDOW_LIMIT:
         raise InvalidSearch('request limit should be <= server threshold of {} but was set to {}'.format(WINDOW_LIMIT, limit))
         
     q_filters = {}


### PR DESCRIPTION
Check that any limit param specified as part of a indicator GET request is at or below WINDOW_LIMIT, which is the max result size allowed to return on the ES index