### PR TITLE
checks ip mask to ensure only /32

### DIFF
--- a/cif/hunter/ipv4_resolve_prefix_whitelist.py
+++ b/cif/hunter/ipv4_resolve_prefix_whitelist.py
@@ -1,7 +1,7 @@
 import logging
 from csirtg_indicator import Indicator, InvalidIndicator
 import arrow
-
+import ipaddress
 
 class Ipv4ResolvePrefixWhitelist(object):
 
@@ -16,7 +16,8 @@ class Ipv4ResolvePrefixWhitelist(object):
         if 'whitelist' not in i.tags:
             return
         
-        if i.indicator.endswith('/24'):
+        # only run this hunter if it's a single address (no CIDRs)
+        if ipaddress.IPv4Network(i.indicator).prefixlen != 32:
             return
 
         prefix = i.indicator.split('.')
@@ -33,7 +34,7 @@ class Ipv4ResolvePrefixWhitelist(object):
         ii.lasttime = arrow.utcnow()
 
         ii.indicator = prefix
-        ii.tags = ['whitelist']
+        ii.tags = ['whitelist', 'hunter']
         ii.confidence = (ii.confidence - 2) if ii.confidence >= 2 else 0
         router.indicators_create(ii)
 


### PR DESCRIPTION
condition to only run this hunter if a single ipv4 is submitted, and add the `hunter` tag. an example problem scenario is if you submit a range like /22 or /18 to be allow listed. this hunter runs at the same time the router does on the zmq sub queue and creates a race condition. if the hunter adds first, the /24 will be created and the upsert on the router side will find the existing range added by the hunter and not add/upsert to the /22 that should have taken precedent.