### PR TITLE
Prevent indicator upserts with diff groups from matching

### DIFF
--- a/cif/httpd/common.py
+++ b/cif/httpd/common.py
@@ -4,9 +4,11 @@ import zlib
 import gzip
 from base64 import b64encode
 
-VALID_FILTERS = ['indicator', 'itype', 'confidence', 'provider', 'limit', 'application', 'nolog', 'tags', 'days',
-                 'hours', 'groups', 'reporttime', 'cc', 'asn', 'asn_desc', 'rdata', 'firsttime', 'lasttime', 'region', 'id',
-                 'portlist', 'protocol', 'tlp']
+VALID_FILTERS = {
+    'indicator', 'itype', 'confidence', 'provider', 'limit', 'application', 'nolog', 'tags', 'days',
+    'hours', 'groups', 'reporttime', 'cc', 'asn', 'asn_desc', 'rdata', 'firsttime', 'lasttime', 'region', 'id',
+    'portlist', 'protocol', 'tlp', 'sort', 'group'
+}
 TOKEN_FILTERS = ['username', 'token']
 
 

--- a/cif/store/zelasticsearch/filters.py
+++ b/cif/store/zelasticsearch/filters.py
@@ -278,7 +278,12 @@ def filter_build(s, filters, token=None):
     # transform all other filters into term=
     s = filter_terms(s, q_filters)
 
-    if q_filters.get('groups'):
+    # indicator search/submit should mostly use singular 'group' field, but the cifsdk uses 
+    # groups (plural) for both indicators and tokens
+    if q_filters.get('group'):
+        q_filters['groups'] = q_filters.pop('group')
+        s = filter_groups(s, q_filters)
+    elif q_filters.get('groups'):
         s = filter_groups(s, q_filters)
     else:
         if token and (not token.get('admin') or token.get('admin') == ''):


### PR DESCRIPTION
Indicator upsert wasn't correctly detecting different groups in certain cases, causing an indicator with all other identical fields to upsert match and increase count of the existing indicator rather than correctly creating a new indicator. This was due to the API only allowing the url param `groups` (plural), but several clients making use of the `group` (singular) param. This appears to have been an issue since the early days of cifv3, and later affected upserts once that feature was added circa 2020.

* fixed the issue
* added test to ensure identical indicators except for diff groups don't upsert (if the config settings use `groups` to upsert match)