### PR TITLE
Fix token creation deserialization due to datetime

### DIFF
--- a/cif/store/zelasticsearch/token.py
+++ b/cif/store/zelasticsearch/token.py
@@ -119,14 +119,14 @@ class TokenManager(TokenManagerPlugin):
         if data.get('token') is None:
             data['token'] = self._generate()
 
-        data['created_at'] = arrow.utcnow().datetime.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        data['created_at'] = arrow.utcnow().datetime.strftime('%Y-%m-%dT%H:%M:%SZ')
         data['created_by'] = token.get('username', token.get('token', 'unknown'))
         
         t = Token(**data)
 
         if t.save():
             connections.get_connection().indices.flush(index=INDEX_NAME)
-            res = t.to_dict()
+            res = data
             res['id'] = t.to_dict(include_meta=True)['_id']
             return res
 


### PR DESCRIPTION
Fix a json deserialization issue when handling token creation b/c the `.to_dict` method of the DocType object returns a dict with a nested datetime object, rather than a str repr of the datetime. This small fix corrects that issue so token creations no longer return an error.