### PR TITLE
Add Integrations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@ For installation instructions and various unix distribution guides, use the **De
 
 https://github.com/csirtgadgets/bearded-avenger-deploymentkit/wiki
 
+# Integrations
+Several integrations, plugins, and extensions have been written to bridge CIFv3 with other tools. Here are some examples to consider building an ecosystem:
+
+* [Python client](https://github.com/csirtgadgets/cifsdk-py-v3)
+* [Dockerized Python client](https://hub.docker.com/r/renisac/cifv3-cli)
+* [PowerShell client](https://github.com/renisac/CIF3-pwsh)
+* [MineMeld plugin](https://github.com/renisac/CIFv3-Minemeld)
+* [Elastic threat intel integration](https://github.com/elastic/integrations/tree/main/packages/ti_cif3)
+* [Threatbus backbone](https://github.com/tenzir/threatbus/tree/main/plugins/apps/threatbus_cif3)
+* [Intelmq output bot](https://github.com/certtools/intelmq/pull/2244)
+
 # Getting Help
  * [the Wiki](https://github.com/csirtgadgets/bearded-avenger-deploymentkit/wiki)
  * [Known Issues](https://github.com/csirtgadgets/bearded-avenger/issues?labels=bug&state=open) 


### PR DESCRIPTION
Could be added to the wiki as well, but thought it might be useful to document various CIFv3 integrations in a single, high-level place like the README.